### PR TITLE
Add ICA baseline and Terra comparison findings

### DIFF
--- a/plans/baseline_current_pipeline_20260724/baseline_comparison_diagnostic.md
+++ b/plans/baseline_current_pipeline_20260724/baseline_comparison_diagnostic.md
@@ -1,0 +1,155 @@
+# Baseline comparison diagnostic — Grace-reviewed ICA component labels
+
+Date: 2026-07-24
+
+Reference standard: Grace expert-reviewed labels from `updated_master_file.csv` in `/cblstore/srv/Analysis/Nate_Projects/Projects/IC_Visual_AI`.
+
+File custody check:
+
+- Grace rows: 679
+- Unique Grace image filenames: 679
+- `training_set.jsonl` + `testing_set.jsonl`: 679 unique filenames
+- Physical images in `SavedImages101723/webp_dataset`: 679 `.webp` files
+- Missing/extra/duplicate filenames across those sets: 0
+
+## Baseline 1 — Autoclean / ICLabel from saved historical EEGLAB ICA
+
+Artifact: `iclabel_full_baseline.csv`
+
+Method:
+
+- Loaded the 12 saved `.set/.fdt` pairs in `SavedFiles/`.
+- Loaded saved EEGLAB ICA decompositions via MNE.
+- Ran `mne-icalabel` ICLabel.
+- Compared ICLabel prediction for each component number against Grace's label.
+
+Coverage and accuracy:
+
+- Rows attempted: 679
+- Rows classified: 679
+- Rows failed: 0
+- Accuracy vs Grace: 448 / 679 = 65.98%
+
+Speed and token usage:
+
+- Recorded wall time for the full ICLabel extraction/classification pass: 134.7 seconds.
+- Mean speed: 0.198 seconds per reviewed component row.
+- Token usage: 0. ICLabel is a local/classical classifier in this run, not an LLM call.
+
+Grace label distribution:
+
+- brain: 224
+- muscle: 200
+- other: 123
+- eye: 86
+- channel: 29
+- heart: 17
+
+ICLabel prediction distribution:
+
+- other: 249
+- brain: 191
+- muscle: 139
+- eye: 47
+- channel: 41
+- heart: 11
+- line_noise: 1
+
+Top confusion/error patterns:
+
+- brain -> other: 71
+- muscle -> other: 41
+- eye -> other: 35
+- muscle -> channel: 14
+- other -> brain: 13
+- eye -> brain: 9
+
+Method caveat:
+
+MNE/ICLabel warned that the loaded raw data did not appear CAR-referenced, were not detected as filtered 1–100 Hz, and the ICA was imported from EEGLAB rather than fitted as a fresh MNE extended-infomax ICA object. This should be labeled as an ICLabel baseline from saved historical EEGLAB ICA, not a fully standardized fresh Autoclean rerun.
+
+## Baseline 2 — Reconstructed old-prompt GPT vision baseline, `gpt-4-turbo-2024-04-09`
+
+Artifact: `reconstructed_gpt4turbo_baseline.csv`
+
+Method:
+
+- Used the same 679 Grace-reviewed image filenames.
+- Used the old `IC_Visual_AI` prompt wording.
+- Used the old S3 image URL pattern.
+- Used `gpt-4-turbo-2024-04-09` as the older vision-capable model.
+- Used the historical key in-process on `cblprod` after explicit approval.
+
+Coverage and accuracy:
+
+- Rows attempted: 679
+- Rows successfully classified: 307
+- Rows failed: 372
+- Successful-subset accuracy vs Grace: 64 / 307 = 20.85%
+- If failures are counted as pipeline failures, end-to-end completed-run accuracy is 64 / 679 = 9.43%, but that number mixes model classification with quota/transport failure and should not be used as pure model accuracy.
+
+Failure breakdown:
+
+- 365 rows failed with `http_429` current quota exceeded.
+- 7 rows failed with provider `http_500` server errors.
+
+Speed and token usage, successful rows only:
+
+- Successful call latency sum, if run serially: 2,663.342 seconds = 44.39 minutes.
+- Mean latency per successful classification: 8.675 seconds.
+- Median latency: 7.272 seconds.
+- 95th percentile latency: 17.452 seconds.
+- Max successful latency: 31.300 seconds.
+- Total successful-row token usage: 364,102 prompt tokens + 36,350 completion tokens = 400,452 total tokens.
+- Mean token usage per successful classification: 1,186.0 prompt tokens + 118.4 completion tokens = 1,304.4 total tokens.
+- Cost was not calculated in this artifact because live model pricing can change and should be pulled from the current official pricing source before using it in planning.
+
+Successful-subset Grace distribution:
+
+- muscle: 87
+- other: 76
+- brain: 67
+- eye: 47
+- channel: 20
+- heart: 10
+
+Successful-subset GPT prediction distribution:
+
+- brain: 235
+- eye: 65
+- muscle: 6
+- channel: 1
+- heart/other: 0
+
+Top GPT confusion patterns on successful rows:
+
+- other -> brain: 60
+- muscle -> brain: 53
+- eye -> brain: 44
+- muscle -> eye: 33
+- other -> eye: 14
+- heart -> brain: 10
+- channel -> eye: 9
+- channel -> brain: 8
+
+Interpretation:
+
+The reconstructed old-prompt GPT baseline is currently much worse than ICLabel on the successful subset. It strongly overpredicts `brain`, almost never emits `other` or `heart`, and substantially misses muscle/eye/channel/other distinctions. This is consistent with the old prompt being too underspecified for diagnostic ICA images: it asks for broad labels but does not teach the model visual rules for topography, time course, spectrum, and segment-panel cues.
+
+## Baseline comparison
+
+| Baseline | Coverage | Accuracy vs Grace | Speed | Token usage | Main issue |
+|---|---:|---:|---:|---:|---|
+| ICLabel from saved EEGLAB ICA | 679/679 | 65.98% | 134.7 sec total; 0.198 sec/component | 0 | Overuses `other`; misses many brain/muscle/eye distinctions |
+| GPT-4 Turbo old prompt, successful subset only | 307/679 | 20.85% | 8.675 sec mean successful call; 17.452 sec p95 | 1,304.4 mean total tokens/success | Severe `brain` overprediction; incomplete due quota |
+
+Current conclusion:
+
+The current/original old-prompt GPT vision approach is not competitive with ICLabel as-is. It is less accurate, slower per component, consumes LLM tokens, and is operationally less reliable under the available historical-key route. The biggest immediate opportunity is prompt/image-format improvement plus structured label definitions, not merely swapping models. However, the GPT baseline is incomplete until quota is available to classify the remaining 372 rows.
+
+Next actions:
+
+1. Preserve current partial GPT baseline as incomplete, not final.
+2. When quota is available, rerun only failed GPT rows and regenerate the full 679-row GPT accuracy.
+3. Use the ICLabel 65.98% result as the complete classical baseline.
+4. Use GPT failure modes to guide prompt improvements: reduce brain overprediction, explicitly teach artifact visual signatures, require calibrated confidence, and include an `other/uncertain` policy.

--- a/plans/baseline_current_pipeline_20260724/baseline_metrics_summary.json
+++ b/plans/baseline_current_pipeline_20260724/baseline_metrics_summary.json
@@ -1,0 +1,37 @@
+{
+  "gpt4_turbo_reconstructed": {
+    "attempted_rows": 679,
+    "successful_rows": 307,
+    "failed_rows": 372,
+    "correct_successful_rows": 64,
+    "successful_subset_accuracy": 0.20846905537459284,
+    "correct_over_all_attempted_rows": 0.09425625920471281,
+    "latency_seconds_successful_only": {
+      "count": 307,
+      "sum_serial_call_time": 2663.342,
+      "mean": 8.675,
+      "median": 7.272,
+      "min": 4.426,
+      "max": 31.3,
+      "p95": 17.452
+    },
+    "tokens_successful_only": {
+      "prompt_tokens": 364102,
+      "completion_tokens": 36350,
+      "total_tokens": 400452,
+      "mean_prompt_tokens_per_success": 1186.0,
+      "mean_completion_tokens_per_success": 118.4,
+      "mean_total_tokens_per_success": 1304.4
+    }
+  },
+  "iclabel_from_saved_eeglab_ica": {
+    "rows": 679,
+    "successful_rows": 679,
+    "failed_rows": 0,
+    "correct_rows": 448,
+    "accuracy": 0.6597938144329897,
+    "wall_seconds_recorded": 134.7,
+    "mean_seconds_per_row": 0.198379970544919,
+    "tokens": 0
+  }
+}

--- a/plans/baseline_current_pipeline_20260724/baseline_status_report.md
+++ b/plans/baseline_current_pipeline_20260724/baseline_status_report.md
@@ -1,0 +1,61 @@
+# ICVision baseline status — 2026-07-24
+
+## Autoclean / ICLabel baseline
+
+Status: complete for the Grace-reviewed historical image set.
+
+- Source folder: `/cblstore/srv/Analysis/Nate_Projects/Projects/IC_Visual_AI`
+- Grace labels: `updated_master_file.csv`
+- EEG/ICA inputs: `SavedFiles/*.set` + matching `*.fdt`
+- Rows evaluated: 679 / 679
+- Unique saved EEGLAB ICA files: 12
+- Baseline method: `mne-icalabel` ICLabel run against saved EEGLAB ICA decompositions loaded through MNE.
+- Accuracy against Grace labels: `0.6597938144329897`
+
+Important method note: MNE/ICLabel emitted warnings that the loaded raw objects did not appear to be CAR-referenced, were not detected as filtered 1–100 Hz, and the ICA objects were loaded as imported EEGLAB decompositions rather than freshly fitted extended-infomax MNE ICA objects. Treat this as the “ICLabel from saved historical EEGLAB ICA” baseline, not as a newly standardized Autoclean rerun baseline.
+
+Artifacts:
+
+- `iclabel_full_baseline.csv`
+- `iclabel_full_baseline.summary.json`
+- `icvision_baseline_file_map.csv`
+- `tools/extract_iclabel_baseline_from_eeglab.py`
+
+Top confusion pairs:
+
+- `brain -> brain`: 153
+- `muscle -> muscle`: 135
+- `other -> other`: 94
+- `brain -> other`: 71
+- `muscle -> other`: 41
+- `eye -> eye`: 39
+- `eye -> other`: 35
+- `channel -> channel`: 16
+- `muscle -> channel`: 14
+- `other -> brain`: 13
+
+## Reconstructed old-prompt GPT vision baseline
+
+Status: runner ready, full live run not complete.
+
+Target model: `gpt-4-turbo-2024-04-09`
+
+Do not use `gpt-4.1-mini` for this baseline.
+
+Current blocker: the approved 1Password `Open Ai Key / credential` value was rejected by direct OpenAI, and the tested ClinCog proxy endpoints returned HTTP 403 / 1010 before reaching the model. The historical server scripts contain a direct OpenAI key that previously worked for fine-tuning-job status checks, but using a hardcoded source credential for new live model calls requires explicit approval after disclosure.
+
+Canonical runner candidates:
+
+- `tools/reconstruct_old_pipeline_baseline.py`: reads historical `training_set.jsonl` / `testing_set.jsonl`, strips Grace answer before model call, writes prediction metrics.
+- `plans/baseline_current_pipeline_20260724/reconstructed_baseline_runner.py`: reads `updated_master_file.csv`, uses old prompt and S3 URL pattern, writes reconstructed-baseline CSV/summary.
+
+Next safe step: after one approved valid route exists, run a one-row smoke with `gpt-4-turbo-2024-04-09`, then the full 679-row reconstructed baseline.
+
+
+## Speed and token metrics added for PR slice
+
+- Accuracy remains the primary metric: ICLabel from saved historical EEGLAB ICA reached 448/679 = 65.98% agreement with Grace. The reconstructed old-prompt GPT-4 Turbo run reached 64/307 = 20.85% on successful rows and 64/679 = 9.43% if transport/quota failures are counted as end-to-end failures.
+- ICLabel speed: 134.7 seconds wall time for 679 rows, about 0.198 seconds/component, with zero LLM token usage.
+- GPT-4 Turbo successful-row speed: mean 8.675 seconds/component, median 7.272 seconds, p95 17.452 seconds.
+- GPT-4 Turbo successful-row token usage: 364,102 prompt + 36,350 completion = 400,452 total tokens across 307 successes; mean 1,304.4 total tokens/success.
+- Public PR custody: row-level Grace labels, row-level GPT predictions, raw model text, server inventories, and historical-key helper scripts are intentionally withheld from the public repository. The committed artifacts are aggregate findings and reusable scripts only.

--- a/plans/baseline_current_pipeline_20260724/terra_updated_prompt_full.summary.json
+++ b/plans/baseline_current_pipeline_20260724/terra_updated_prompt_full.summary.json
@@ -1,0 +1,67 @@
+{
+  "total_rows": 679,
+  "completed_rows": 679,
+  "failed_rows": 0,
+  "accuracy_completed_rows": 0.49337260677466865,
+  "correct_completed_rows": 335,
+  "accuracy_all_rows": 0.49337260677466865,
+  "label_distribution_true": {
+    "channel_noise": 29,
+    "other_artifact": 123,
+    "brain": 224,
+    "muscle": 200,
+    "eye": 86,
+    "heart": 17
+  },
+  "label_distribution_predicted": {
+    "channel_noise": 176,
+    "brain": 199,
+    "other_artifact": 90,
+    "muscle": 176,
+    "line_noise": 20,
+    "eye": 18
+  },
+  "confusion": {
+    "channel_noise->channel_noise": 24,
+    "other_artifact->channel_noise": 45,
+    "brain->brain": 134,
+    "channel_noise->other_artifact": 4,
+    "muscle->muscle": 128,
+    "eye->brain": 29,
+    "muscle->channel_noise": 54,
+    "other_artifact->other_artifact": 34,
+    "other_artifact->muscle": 21,
+    "brain->muscle": 21,
+    "brain->other_artifact": 28,
+    "muscle->line_noise": 7,
+    "muscle->other_artifact": 7,
+    "brain->line_noise": 7,
+    "other_artifact->brain": 18,
+    "brain->channel_noise": 32,
+    "eye->channel_noise": 21,
+    "eye->eye": 15,
+    "other_artifact->line_noise": 5,
+    "eye->other_artifact": 17,
+    "heart->brain": 14,
+    "eye->muscle": 3,
+    "muscle->brain": 4,
+    "eye->line_noise": 1,
+    "heart->muscle": 2,
+    "heart->eye": 1,
+    "brain->eye": 2,
+    "channel_noise->muscle": 1
+  },
+  "failure_types": {},
+  "tokens_completed_rows": {
+    "input_tokens": 838565,
+    "output_tokens": 124512,
+    "total_tokens": 963077,
+    "mean_total_tokens": 1418.376
+  },
+  "latency_seconds_completed_rows": {
+    "sum": 3973.596,
+    "mean": 5.852,
+    "min": 2.617,
+    "max": 24.289
+  }
+}

--- a/plans/baseline_current_pipeline_20260724/terra_vs_iclabel_comparison.md
+++ b/plans/baseline_current_pipeline_20260724/terra_vs_iclabel_comparison.md
@@ -1,0 +1,112 @@
+# Terra updated-prompt baseline vs ICLabel baseline — Grace-reviewed ICA components
+
+Date: 2026-07-24
+
+Reference standard: Grace expert-reviewed labels for the same 679 historical IC_Visual_AI component images used in the prior baseline slice.
+
+Scope:
+
+- Baseline EEG/classical comparator: ICLabel run from saved historical EEGLAB ICA files.
+- New model comparator: `gpt-5.6-terra` through the governed ClinCog Responses route using the updated diagnostic prompt from `.gate3-integration/prompts/default.txt`.
+- No EEG or ICA data were modified. Terra classified already-rendered component images only.
+- Row-level labels/predictions remain private because this repository is public. This artifact reports aggregate metrics only.
+
+## Summary
+
+| Metric | ICLabel baseline | Terra updated prompt | Difference, Terra - ICLabel |
+|---|---:|---:|---:|
+| Components attempted | 679 | 679 | 0 |
+| Components completed | 679 | 679 | 0 |
+| Failed classifications | 0 | 0 | 0 |
+| Correct vs Grace | 448 | 335 | -113 |
+| Accuracy vs Grace | 65.98% | 49.34% | -16.64 percentage points |
+| Observed wall time | 134.7 sec | 502.2 sec with 8 workers | +367.5 sec |
+| Mean per-component call/classification time | 0.198 sec/component | 5.852 sec/model call | +5.654 sec |
+| Total LLM tokens | 0 | 963,077 | +963,077 |
+| Mean LLM tokens/component | 0 | 1,418.4 | +1,418.4 |
+
+Bottom line: Terra with the updated prompt is much better than the reconstructed old-prompt GPT baseline, but it does not beat the ICLabel baseline on this Grace-reviewed dataset. Accuracy is the priority metric, so ICLabel remains the stronger baseline today.
+
+## Terra operational result
+
+The Terra route itself worked cleanly once pointed at the governed ClinCog host:
+
+- Endpoint profile: `https://ai.clincognition.com/v1/responses`
+- Model: `gpt-5.6-terra`
+- Prompt: updated diagnostic ICA prompt
+- Rows completed: 679/679
+- Failures: 0
+- Observed concurrent wall time: 502.2 seconds using 8 workers
+- Sum of successful call latencies: 3,973.596 seconds
+- Mean latency: 5.852 seconds/component
+- Median latency: 5.495 seconds/component
+- 95th percentile latency: 8.969 seconds/component
+- Max latency: 24.289 seconds/component
+- Total tokens: 838,565 input + 124,512 output = 963,077 total
+
+This is a major operational improvement over the reconstructed old-prompt GPT-4 Turbo baseline, which only completed 307/679 rows under the historical-key route and failed 372 rows, mostly due quota.
+
+## Per-label comparison
+
+| Label | Support | ICLabel precision | ICLabel recall | ICLabel F1 | Terra precision | Terra recall | Terra F1 | Terra read |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| brain | 224 | 80.10% | 68.30% | 73.73% | 67.34% | 59.82% | 63.36% | Worse than ICLabel on all three metrics. |
+| channel_noise | 29 | 39.02% | 55.17% | 45.71% | 13.64% | 82.76% | 23.41% | Better recall, much worse precision; Terra over-calls channel noise. |
+| eye | 86 | 82.98% | 45.35% | 58.65% | 83.33% | 17.44% | 28.85% | Similar precision, much worse recall. |
+| heart | 17 | 100.00% | 64.71% | 78.57% | n/a | 0.00% | 0.00% | Terra did not emit heart at all. |
+| muscle | 200 | 97.12% | 67.50% | 79.65% | 72.73% | 64.00% | 68.09% | Slightly lower recall and substantially lower precision. |
+| other_artifact | 123 | 37.75% | 76.42% | 50.54% | 37.78% | 27.64% | 31.92% | Similar precision, much worse recall. |
+
+## Where Terra excels
+
+Against ICLabel, Terra's only clear metric win is `channel_noise` recall:
+
+- ICLabel channel-noise recall: 16/29 = 55.17%.
+- Terra channel-noise recall: 24/29 = 82.76%.
+
+That may matter if the near-term goal is to avoid missing bad-channel-like components. But the tradeoff is severe: Terra predicted `channel_noise` 176 times for only 29 true channel-noise cases, so precision fell to 13.64%. In practical review terms, Terra is acting like an aggressive channel-noise screener, not an accurate final classifier.
+
+Terra also excelled operationally compared with the old GPT baseline, not compared with ICLabel:
+
+- Old GPT-4 Turbo reconstructed baseline completed only 307/679 rows.
+- Terra completed 679/679 rows with zero failures.
+- Old GPT overpredicted `brain`; Terra reduced that specific failure but introduced a different bias toward `channel_noise`.
+
+## Main Terra failure modes
+
+Top Terra confusions:
+
+- muscle -> channel_noise: 54
+- other_artifact -> channel_noise: 45
+- brain -> channel_noise: 32
+- eye -> brain: 29
+- brain -> other_artifact: 28
+- brain -> muscle: 21
+- other_artifact -> muscle: 21
+- eye -> channel_noise: 21
+- other_artifact -> brain: 18
+- eye -> other_artifact: 17
+- heart -> brain: 14
+
+Interpretation:
+
+1. The updated prompt made Terra less brain-happy than the old GPT baseline, but it overcorrected toward `channel_noise`.
+2. Terra is still poor at eye recall: it recognized only 15/86 true eye components.
+3. Terra completely missed the heart class: 0/17 true heart components were labeled heart.
+4. Terra's `other_artifact` behavior is too conservative: many true other artifacts are being forced into channel_noise, brain, or muscle.
+
+## Recommendation
+
+Do not treat the current Terra prompt as an accuracy improvement over the EEG/ICLabel baseline. It is a useful governed runtime and a much more reliable LLM route than the old GPT baseline, but its current classification behavior needs another prompt/image-evidence iteration before it can support the publication-oriented accuracy goal.
+
+Minimal next prompt changes to test:
+
+1. Tighten channel-noise criteria: require a truly isolated single-electrode scalp map before using `channel_noise`; otherwise prefer muscle or other_artifact.
+2. Strengthen eye criteria: frontal/periocular topography plus slow blink/saccade activity should beat generic brain unless other panels contradict it.
+3. Strengthen heart criteria: regular ~1 Hz QRS-like time-series deflections should be decisive even if the scalp map is broad or non-brain-like.
+4. Add an explicit uncertainty policy: when cues are mixed, prefer `other_artifact` over forcing channel_noise.
+5. Keep this dataset as the fixed validation set; do not tune against the final publication test set without a held-out split.
+
+## Public custody boundary
+
+The row-level Terra CSV, row-level ICLabel CSV, Grace label table, and remote inventories are intentionally not committed because this repository is public and those artifacts include real research filenames/labels. Aggregate metrics and reusable scripts are committed.

--- a/plans/baseline_current_pipeline_20260724/terra_vs_iclabel_comparison.summary.json
+++ b/plans/baseline_current_pipeline_20260724/terra_vs_iclabel_comparison.summary.json
@@ -1,0 +1,276 @@
+{
+  "comparison_date": "2026-07-24",
+  "reference": "Grace expert-reviewed labels, 679 components",
+  "iclabel_baseline": {
+    "rows": 679,
+    "correct": 448,
+    "accuracy": 0.6597938144329897,
+    "wall_seconds": 134.7,
+    "mean_seconds_per_component": 0.198379970544919,
+    "tokens_total": 0,
+    "true_distribution": {
+      "eye": 86,
+      "brain": 224,
+      "muscle": 200,
+      "heart": 17,
+      "channel_noise": 29,
+      "other_artifact": 123
+    },
+    "predicted_distribution": {
+      "eye": 47,
+      "brain": 191,
+      "muscle": 139,
+      "heart": 11,
+      "other_artifact": 249,
+      "channel_noise": 41,
+      "line_noise": 1
+    },
+    "per_label": {
+      "brain": {
+        "support": 224,
+        "predicted": 191,
+        "tp": 153,
+        "fp": 38,
+        "fn": 71,
+        "precision": 0.8010471204188482,
+        "recall": 0.6830357142857143,
+        "f1": 0.7373493975903614
+      },
+      "channel_noise": {
+        "support": 29,
+        "predicted": 41,
+        "tp": 16,
+        "fp": 25,
+        "fn": 13,
+        "precision": 0.3902439024390244,
+        "recall": 0.5517241379310345,
+        "f1": 0.4571428571428572
+      },
+      "eye": {
+        "support": 86,
+        "predicted": 47,
+        "tp": 39,
+        "fp": 8,
+        "fn": 47,
+        "precision": 0.8297872340425532,
+        "recall": 0.45348837209302323,
+        "f1": 0.5864661654135338
+      },
+      "heart": {
+        "support": 17,
+        "predicted": 11,
+        "tp": 11,
+        "fp": 0,
+        "fn": 6,
+        "precision": 1.0,
+        "recall": 0.6470588235294118,
+        "f1": 0.7857142857142858
+      },
+      "line_noise": {
+        "support": 0,
+        "predicted": 1,
+        "tp": 0,
+        "fp": 1,
+        "fn": 0,
+        "precision": 0.0,
+        "recall": null,
+        "f1": 0
+      },
+      "muscle": {
+        "support": 200,
+        "predicted": 139,
+        "tp": 135,
+        "fp": 4,
+        "fn": 65,
+        "precision": 0.9712230215827338,
+        "recall": 0.675,
+        "f1": 0.7964601769911505
+      },
+      "other_artifact": {
+        "support": 123,
+        "predicted": 249,
+        "tp": 94,
+        "fp": 155,
+        "fn": 29,
+        "precision": 0.37751004016064255,
+        "recall": 0.7642276422764228,
+        "f1": 0.5053763440860216
+      }
+    },
+    "top_confusions": {
+      "brain->other_artifact": 71,
+      "muscle->other_artifact": 41,
+      "eye->other_artifact": 35,
+      "muscle->channel_noise": 14,
+      "other_artifact->brain": 13,
+      "eye->brain": 9,
+      "other_artifact->channel_noise": 8,
+      "muscle->brain": 7,
+      "channel_noise->other_artifact": 7,
+      "heart->brain": 5,
+      "other_artifact->eye": 5,
+      "channel_noise->brain": 4
+    }
+  },
+  "terra_updated_prompt": {
+    "rows": 679,
+    "correct": 335,
+    "accuracy": 0.49337260677466865,
+    "failed_rows": 0,
+    "wall_seconds_observed_concurrent": 502.2,
+    "sum_successful_call_latency_seconds": 3973.596,
+    "mean_seconds_per_component_call": 5.852,
+    "median_seconds_per_component_call": 5.412,
+    "p95_seconds_per_component_call": 9.12,
+    "max_seconds_per_component_call": 24.289,
+    "tokens_total": 963077,
+    "input_tokens_total": 838565,
+    "output_tokens_total": 124512,
+    "mean_total_tokens_per_component": 1418.376,
+    "true_distribution": {
+      "channel_noise": 29,
+      "other_artifact": 123,
+      "brain": 224,
+      "muscle": 200,
+      "eye": 86,
+      "heart": 17
+    },
+    "predicted_distribution": {
+      "channel_noise": 176,
+      "brain": 199,
+      "other_artifact": 90,
+      "muscle": 176,
+      "line_noise": 20,
+      "eye": 18
+    },
+    "per_label": {
+      "brain": {
+        "support": 224,
+        "predicted": 199,
+        "tp": 134,
+        "fp": 65,
+        "fn": 90,
+        "precision": 0.6733668341708543,
+        "recall": 0.5982142857142857,
+        "f1": 0.6335697399527187
+      },
+      "channel_noise": {
+        "support": 29,
+        "predicted": 176,
+        "tp": 24,
+        "fp": 152,
+        "fn": 5,
+        "precision": 0.13636363636363635,
+        "recall": 0.8275862068965517,
+        "f1": 0.23414634146341462
+      },
+      "eye": {
+        "support": 86,
+        "predicted": 18,
+        "tp": 15,
+        "fp": 3,
+        "fn": 71,
+        "precision": 0.8333333333333334,
+        "recall": 0.1744186046511628,
+        "f1": 0.2884615384615385
+      },
+      "heart": {
+        "support": 17,
+        "predicted": 0,
+        "tp": 0,
+        "fp": 0,
+        "fn": 17,
+        "precision": null,
+        "recall": 0.0,
+        "f1": 0
+      },
+      "line_noise": {
+        "support": 0,
+        "predicted": 20,
+        "tp": 0,
+        "fp": 20,
+        "fn": 0,
+        "precision": 0.0,
+        "recall": null,
+        "f1": 0
+      },
+      "muscle": {
+        "support": 200,
+        "predicted": 176,
+        "tp": 128,
+        "fp": 48,
+        "fn": 72,
+        "precision": 0.7272727272727273,
+        "recall": 0.64,
+        "f1": 0.6808510638297872
+      },
+      "other_artifact": {
+        "support": 123,
+        "predicted": 90,
+        "tp": 34,
+        "fp": 56,
+        "fn": 89,
+        "precision": 0.37777777777777777,
+        "recall": 0.2764227642276423,
+        "f1": 0.31924882629107987
+      }
+    },
+    "top_confusions": {
+      "muscle->channel_noise": 54,
+      "other_artifact->channel_noise": 45,
+      "brain->channel_noise": 32,
+      "eye->brain": 29,
+      "brain->other_artifact": 28,
+      "other_artifact->muscle": 21,
+      "brain->muscle": 21,
+      "eye->channel_noise": 21,
+      "other_artifact->brain": 18,
+      "eye->other_artifact": 17,
+      "heart->brain": 14,
+      "muscle->line_noise": 7
+    }
+  },
+  "deltas": {
+    "accuracy_points_terra_minus_iclabel": -16.642,
+    "terra_correct_minus_iclabel_correct": -113,
+    "terra_mean_call_seconds_minus_iclabel_mean_row_seconds": 5.654,
+    "terra_tokens_minus_iclabel_tokens": 963077
+  },
+  "per_label_terra_minus_iclabel": {
+    "brain": {
+      "precision_delta": -0.128,
+      "recall_delta": -0.085,
+      "f1_delta": -0.104
+    },
+    "channel_noise": {
+      "precision_delta": -0.254,
+      "recall_delta": 0.276,
+      "f1_delta": -0.223
+    },
+    "eye": {
+      "precision_delta": 0.004,
+      "recall_delta": -0.279,
+      "f1_delta": -0.298
+    },
+    "heart": {
+      "precision_delta": null,
+      "recall_delta": -0.647,
+      "f1_delta": -0.786
+    },
+    "line_noise": {
+      "precision_delta": 0.0,
+      "recall_delta": null,
+      "f1_delta": 0
+    },
+    "muscle": {
+      "precision_delta": -0.244,
+      "recall_delta": -0.035,
+      "f1_delta": -0.116
+    },
+    "other_artifact": {
+      "precision_delta": 0.0,
+      "recall_delta": -0.488,
+      "f1_delta": -0.186
+    }
+  }
+}

--- a/tools/extract_iclabel_baseline_from_eeglab.py
+++ b/tools/extract_iclabel_baseline_from_eeglab.py
@@ -1,0 +1,203 @@
+"""Extract an ICLabel baseline from saved EEGLAB raw+ICA files.
+
+This script is for the historical IC_Visual_AI Grace-reviewed dataset. It reads
+Grace labels from ``updated_master_file.csv``, maps each image filename to the
+corresponding ``SavedFiles/*.set`` + ``*.fdt`` pair, loads the saved ICA from
+EEGLAB with MNE, runs ICLabel, and writes row-level agreement metrics.
+
+It does not modify EEG/ICA data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import mne
+from mne_icalabel import label_components
+
+
+GRACE_LABELS = {
+    "brain": "brain",
+    "brain activity": "brain",
+    "eye": "eye",
+    "eye blink": "eye",
+    "eog": "eye",
+    "muscle": "muscle",
+    "muscle artifact": "muscle",
+    "heart": "heart",
+    "heart beat": "heart",
+    "cardiac": "heart",
+    "cardiac artifact": "heart",
+    "channel": "channel",
+    "channel noise": "channel",
+    "line noise": "line_noise",
+    "other": "other",
+}
+
+
+def normalize_label(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[_\-]+", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return GRACE_LABELS.get(text, text.replace(" ", "_") or "unknown")
+
+
+def parse_image_name(image_filename: str) -> tuple[str, str, int]:
+    match = re.match(
+        r"(?P<subject>\d{4})_(?P<condition>vdaudio|vdnoaudio)_ica_comp_(?P<component>\d+)\.webp$",
+        image_filename.lower(),
+    )
+    if not match:
+        raise ValueError(f"Cannot parse image filename: {image_filename}")
+    return match.group("subject"), match.group("condition"), int(match.group("component"))
+
+
+def set_candidates(subject: str, condition: str) -> list[str]:
+    condition_variants = {
+        "vdaudio": ["VDaudio", "VDAudio", "VD_audio"],
+        "vdnoaudio": ["VDnoaudio", "VDNoAudio", "VD_noaudio"],
+    }[condition]
+    return [f"{subject}_{variant}_ICA.set" for variant in condition_variants]
+
+
+def find_set(saved_files_dir: Path, subject: str, condition: str) -> Path:
+    existing = {path.name.lower(): path for path in saved_files_dir.glob("*.set")}
+    for candidate in set_candidates(subject, condition):
+        path = existing.get(candidate.lower())
+        if path:
+            return path
+    raise FileNotFoundError(f"No .set found for {subject} {condition}")
+
+
+def classify_set(set_path: Path) -> dict[str, Any]:
+    started = time.perf_counter()
+    raw = mne.io.read_raw_eeglab(set_path, preload=True, verbose="error")
+    ica = mne.preprocessing.read_ica_eeglab(set_path, verbose="error")
+    result = label_components(raw, ica, method="iclabel")
+    elapsed = time.perf_counter() - started
+    labels = list(result["labels"])
+    confidence = result.get("y_pred_proba")
+    confidence_values = [float(x) for x in confidence] if confidence is not None else [""] * len(labels)
+    return {
+        "labels": labels,
+        "confidence": confidence_values,
+        "n_components": len(labels),
+        "elapsed_seconds": elapsed,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--labels-csv", type=Path, required=True)
+    parser.add_argument("--saved-files-dir", type=Path, required=True)
+    parser.add_argument("--output-csv", type=Path, required=True)
+    parser.add_argument("--summary-json", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args()
+
+    with args.labels_csv.open("r", encoding="utf-8-sig", newline="") as handle:
+        grace_rows = list(csv.DictReader(handle))
+    if args.limit is not None:
+        grace_rows = grace_rows[: args.limit]
+
+    grouped: dict[Path, list[dict[str, Any]]] = {}
+    prepared: list[dict[str, Any]] = []
+    for row in grace_rows:
+        subject, condition, component_number = parse_image_name(row["image_filename"])
+        set_path = find_set(args.saved_files_dir, subject, condition)
+        item = {
+            **row,
+            "subject": subject,
+            "condition": condition,
+            "component_number": component_number,
+            "component_index": component_number - 1,
+            "set_path": str(set_path),
+            "grace_label": normalize_label(row.get("compType")),
+        }
+        grouped.setdefault(set_path, []).append(item)
+        prepared.append(item)
+
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+
+    classified: dict[Path, dict[str, Any]] = {}
+    for index, set_path in enumerate(grouped, start=1):
+        print(f"{index}/{len(grouped)} ICLabel {set_path}", flush=True)
+        classified[set_path] = classify_set(set_path)
+
+    fieldnames = [
+        "image_filename",
+        "subject",
+        "condition",
+        "component_number",
+        "component_index",
+        "set_path",
+        "grace_label",
+        "iclabel_label",
+        "iclabel_confidence",
+        "agreement",
+        "status",
+        "error",
+    ]
+    output_rows: list[dict[str, Any]] = []
+    for item in prepared:
+        set_path = Path(item["set_path"])
+        component_index = int(item["component_index"])
+        result = classified[set_path]
+        out = {key: item.get(key, "") for key in fieldnames}
+        out["status"] = "ok"
+        out["error"] = ""
+        if component_index < 0 or component_index >= result["n_components"]:
+            out["status"] = "missing_component"
+            out["error"] = f"component_index {component_index} outside 0..{result['n_components'] - 1}"
+            out["iclabel_label"] = ""
+            out["iclabel_confidence"] = ""
+            out["agreement"] = ""
+        else:
+            iclabel_label = normalize_label(result["labels"][component_index])
+            out["iclabel_label"] = iclabel_label
+            out["iclabel_confidence"] = result["confidence"][component_index]
+            out["agreement"] = iclabel_label == item["grace_label"]
+        output_rows.append(out)
+
+    with args.output_csv.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(output_rows)
+
+    ok_rows = [row for row in output_rows if row["status"] == "ok"]
+    correct = sum(1 for row in ok_rows if row["agreement"] is True)
+    summary = {
+        "baseline_type": "autoclean_iclabel_from_saved_eeglab_ica",
+        "not_historical_saved_predictions": True,
+        "labels_csv": str(args.labels_csv),
+        "saved_files_dir": str(args.saved_files_dir),
+        "rows_total": len(output_rows),
+        "rows_ok": len(ok_rows),
+        "rows_failed": len(output_rows) - len(ok_rows),
+        "unique_set_files": len(grouped),
+        "accuracy": correct / len(ok_rows) if ok_rows else None,
+        "grace_distribution": dict(Counter(row["grace_label"] for row in ok_rows)),
+        "iclabel_distribution": dict(Counter(row["iclabel_label"] for row in ok_rows)),
+        "confusion": dict(
+            Counter(f"{row['grace_label']}->{row['iclabel_label']}" for row in ok_rows)
+        ),
+        "notes": [
+            "Uses saved EEGLAB ICA decomposition via mne.preprocessing.read_ica_eeglab.",
+            "Maps image component numbers as 1-based; ICLabel arrays are indexed with component_number - 1.",
+        ],
+    }
+    args.summary_json.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary, indent=2), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/generate_channel_loading_sidecar.py
+++ b/tools/generate_channel_loading_sidecar.py
@@ -1,0 +1,202 @@
+"""Generate label-free channel-loading evidence for ICA component images.
+
+This private evaluation helper reads EEGLAB .set files and writes JSONL evidence
+payloads keyed by historical ICVision image filenames. It does not read, write,
+or modify EEG samples, ICA exclusions, or Grace labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import scipy.io as sio
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def compact(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def parse_image_filename(filename: str) -> tuple[str, str, int]:
+    match = re.match(r"^(\d+)_vd(no)?audio_ica_comp_(\d+)\.webp$", filename.lower())
+    if not match:
+        raise ValueError(f"Unrecognized image filename format: {filename}")
+    source_id = match.group(1)
+    condition = "vdnoaudio" if match.group(2) else "vdaudio"
+    component_number = int(match.group(3))
+    return source_id, condition, component_number
+
+
+def find_set_file(set_dir: Path, source_id: str, condition: str) -> Path:
+    candidates = []
+    for path in set_dir.glob(f"{source_id}*_ICA.set"):
+        name = compact(path.name)
+        if condition == "vdnoaudio":
+            if "vdnoaudio" in name:
+                candidates.append(path)
+        elif condition == "vdaudio":
+            if "vdaudio" in name and "vdnoaudio" not in name:
+                candidates.append(path)
+    if len(candidates) != 1:
+        raise ValueError(f"Expected one .set for {source_id} {condition}, found {[str(p) for p in candidates]}")
+    return candidates[0]
+
+
+def mat_get(mat: dict[str, Any], name: str) -> Any:
+    if name in mat:
+        return mat[name]
+    eeg = mat.get("EEG")
+    if eeg is not None:
+        return getattr(eeg, name, None)
+    return None
+
+
+def chanloc_value(chan: Any, name: str) -> Any:
+    return getattr(chan, name, None)
+
+
+def channel_metadata(chanlocs: Any) -> list[dict[str, Any]]:
+    meta = []
+    for idx, chan in enumerate(np.atleast_1d(chanlocs)):
+        label = str(chanloc_value(chan, "labels") or f"chan{idx + 1}")
+        coords = []
+        for axis in ("X", "Y", "Z"):
+            value = chanloc_value(chan, axis)
+            try:
+                coords.append(float(value))
+            except (TypeError, ValueError):
+                coords.append(float("nan"))
+        meta.append({"label": label, "xyz": coords})
+    return meta
+
+
+def nearest_neighbor_support(abs_loadings: np.ndarray, channels: list[dict[str, Any]], top_index: int, k: int = 4) -> float | None:
+    top_xyz = np.array(channels[top_index]["xyz"], dtype=float)
+    if not np.isfinite(top_xyz).all():
+        return None
+    distances = []
+    for idx, item in enumerate(channels):
+        if idx == top_index:
+            continue
+        xyz = np.array(item["xyz"], dtype=float)
+        if not np.isfinite(xyz).all():
+            continue
+        distances.append((float(np.linalg.norm(xyz - top_xyz)), idx))
+    if not distances:
+        return None
+    nearest = [idx for _, idx in sorted(distances)[:k]]
+    max_loading = float(abs_loadings[top_index])
+    if max_loading <= 0:
+        return None
+    return float(np.mean(abs_loadings[nearest]) / max_loading)
+
+
+def component_evidence(set_path: Path, component_number: int) -> dict[str, Any]:
+    mat = sio.loadmat(set_path, squeeze_me=True, struct_as_record=False)
+    icawinv = mat_get(mat, "icawinv")
+    chanlocs = mat_get(mat, "chanlocs")
+    if icawinv is None:
+        raise ValueError(f"Missing icawinv in {set_path}")
+    matrix = np.asarray(icawinv, dtype=float)
+    if matrix.ndim != 2:
+        raise ValueError(f"icawinv is not 2D in {set_path}: {matrix.shape}")
+    component_index_zero_based = component_number - 1
+    if component_index_zero_based < 0 or component_index_zero_based >= matrix.shape[1]:
+        raise ValueError(f"Component {component_number} out of range for {set_path} with {matrix.shape[1]} components")
+    loadings = matrix[:, component_index_zero_based]
+    abs_loadings = np.abs(loadings)
+    order = np.argsort(abs_loadings)[::-1]
+    top_index = int(order[0])
+    second = float(abs_loadings[order[1]]) if len(order) > 1 else 0.0
+    largest = float(abs_loadings[top_index])
+    ratio = largest / second if second > 0 else None
+    channels = channel_metadata(chanlocs) if chanlocs is not None else [{"label": f"chan{i + 1}", "xyz": [math.nan, math.nan, math.nan]} for i in range(matrix.shape[0])]
+    support = nearest_neighbor_support(abs_loadings, channels, top_index)
+    above_half = int(np.sum(abs_loadings >= largest * 0.5)) if largest > 0 else 0
+    above_quarter = int(np.sum(abs_loadings >= largest * 0.25)) if largest > 0 else 0
+    return {
+        "evidence_schema_version": "channel_loading_v1",
+        "top_channel_label": channels[top_index]["label"],
+        "top_channel_index_one_based": top_index + 1,
+        "largest_abs_loading": round(largest, 8),
+        "second_largest_abs_loading": round(second, 8),
+        "largest_to_second_largest_ratio": round(ratio, 8) if ratio is not None else None,
+        "channels_above_50pct_of_max": above_half,
+        "channels_above_25pct_of_max": above_quarter,
+        "nearest_neighbor_support_ratio_k4": round(support, 8) if support is not None else None,
+    }
+
+
+def read_input_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if not reader.fieldnames or "image_filename" not in reader.fieldnames:
+            raise ValueError("Input CSV must contain image_filename")
+        rows = []
+        seen = set()
+        for row in reader:
+            filename = (row.get("image_filename") or "").strip()
+            if not filename or filename in seen:
+                continue
+            parse_image_filename(filename)
+            seen.add(filename)
+            rows.append({"image_filename": filename})
+    if not rows:
+        raise ValueError("Input CSV produced no rows")
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-csv", type=Path, required=True)
+    parser.add_argument("--set-dir", type=Path, required=True)
+    parser.add_argument("--output-jsonl", type=Path, required=True)
+    parser.add_argument("--summary-json", type=Path, required=True)
+    args = parser.parse_args()
+
+    rows = read_input_rows(args.input_csv)
+    args.output_jsonl.parent.mkdir(parents=True, exist_ok=True)
+    set_cache: dict[Path, dict[int, dict[str, Any]]] = {}
+    output_rows = []
+    set_files = Counter()
+    with args.output_jsonl.open("w", encoding="utf-8") as out:
+        for row in rows:
+            filename = row["image_filename"]
+            source_id, condition, component_number = parse_image_filename(filename)
+            set_path = find_set_file(args.set_dir, source_id, condition)
+            set_files[str(set_path)] += 1
+            payload = component_evidence(set_path, component_number)
+            record = {"row_key": filename, "image_filename": filename, "evidence": payload}
+            out.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+            output_rows.append(record)
+    summary = {
+        "rows": len(output_rows),
+        "evidence_schema_version": "channel_loading_v1",
+        "output_jsonl_sha256": sha256_file(args.output_jsonl),
+        "unique_set_files": len(set_files),
+        "set_file_row_counts": {Path(path).name: count for path, count in sorted(set_files.items())},
+        "set_file_sha256_by_basename": {Path(path).name: sha256_file(Path(path)) for path in sorted(set_files)},
+    }
+    args.summary_json.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reconstruct_old_pipeline_baseline.py
+++ b/tools/reconstruct_old_pipeline_baseline.py
@@ -1,0 +1,298 @@
+"""Reconstruct the old IC_Visual_AI model-performance baseline.
+
+This script intentionally treats the historical JSONL files as supervised
+examples: it reuses only the old system prompt and image URL, discards the
+assistant/human label before the model call, then compares the fresh model
+prediction against the Grace-derived label.
+
+Outputs are local analysis artifacts only. The script never edits EEG/ICA data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+LABEL_MAP = {
+    "brain": "brain",
+    "brain activity": "brain",
+    "eye": "eye",
+    "eye blink": "eye",
+    "eog": "eye",
+    "muscle": "muscle",
+    "muscle artifact": "muscle",
+    "heart": "heart",
+    "cardiac": "heart",
+    "cardiac artifact": "heart",
+    "ecg": "heart",
+    "channel noise": "channel_noise",
+    "channel_noise": "channel_noise",
+    "ch_noise": "channel_noise",
+    "line noise": "line_noise",
+    "line_noise": "line_noise",
+    "other": "other",
+    "other artifact": "other",
+    "other_artifact": "other",
+}
+
+
+def sanitize_error(text: str) -> str:
+    """Remove credential-shaped substrings from provider error messages."""
+    text = re.sub(r"\b(?:sk|clp)(?:[-_][A-Za-z0-9*]+)+", "CREDENTIAL-REDACTED", text)
+    return re.sub(r"Bearer\s+[^\"\s,}]+", "Bearer CREDENTIAL-REDACTED", text)
+
+
+def _normalize_label(value: object) -> str:
+    text = str(value or "").strip().lower().replace("-", " ").replace("_", " ")
+    text = re.sub(r"\s+", " ", text)
+    return LABEL_MAP.get(text, text.replace(" ", "_") or "unknown")
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", stripped, re.DOTALL)
+        if not match:
+            raise
+        parsed = json.loads(match.group(0))
+    if not isinstance(parsed, dict):
+        raise ValueError("model response JSON is not an object")
+    return parsed
+
+
+def _load_examples(path: Path) -> list[dict[str, Any]]:
+    examples: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            messages = payload["messages"]
+            system_prompt = messages[0]["content"]
+            user_content = messages[1]["content"]
+            image_url = user_content[0]["image_url"]["url"]
+            answer = json.loads(messages[2]["content"])
+            true_label = _normalize_label(answer.get("classification"))
+            image_name = image_url.rsplit("/", 1)[-1]
+            examples.append(
+                {
+                    "source_file": str(path),
+                    "line_number": line_number,
+                    "image_url": image_url,
+                    "image_filename": image_name,
+                    "system_prompt": system_prompt,
+                    "true_label": true_label,
+                    "true_label_raw": answer.get("classification"),
+                }
+            )
+    return examples
+
+
+def _message_text(response: dict[str, Any]) -> str:
+    output = response.get("output") or []
+    for item in output:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content") or []:
+            text = content.get("text")
+            if text:
+                return text
+    fallback = response.get("output_text")
+    if fallback:
+        return str(fallback)
+    return ""
+
+
+def _responses_create(
+    *,
+    api_key: str,
+    base_url: str,
+    model: str,
+    example: dict[str, Any],
+) -> dict[str, Any]:
+    body = json.dumps(
+        {
+            "model": model,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": example["system_prompt"]},
+                        {"type": "input_image", "image_url": example["image_url"]},
+                    ],
+                }
+            ],
+            "temperature": 0.2,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        base_url.rstrip("/") + "/responses",
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(sanitize_error(f"HTTP {exc.code}: {detail[:500]}")) from exc
+
+
+def classify_example(api_key: str, base_url: str, model: str, example: dict[str, Any]) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = _responses_create(api_key=api_key, base_url=base_url, model=model, example=example)
+    elapsed = time.perf_counter() - started
+    raw_text = _message_text(response)
+    parsed = _extract_json(raw_text)
+    usage = response.get("usage") or {}
+    predicted_raw = parsed.get("classification", parsed.get("label"))
+    predicted = _normalize_label(predicted_raw)
+    confidence = parsed.get("confidence")
+    try:
+        confidence = float(confidence)
+    except (TypeError, ValueError):
+        confidence = None
+    return {
+        **{k: example[k] for k in ("source_file", "line_number", "image_url", "image_filename", "true_label", "true_label_raw")},
+        "model": model,
+        "predicted_label": predicted,
+        "predicted_label_raw": predicted_raw,
+        "confidence": confidence,
+        "reasoning": parsed.get("reasoning", parsed.get("reason", "")),
+        "raw_response": raw_text,
+        "input_tokens": usage.get("input_tokens"),
+        "output_tokens": usage.get("output_tokens"),
+        "elapsed_seconds": round(elapsed, 3),
+        "correct": predicted == example["true_label"],
+        "error": "",
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "source_file",
+        "line_number",
+        "image_filename",
+        "image_url",
+        "model",
+        "true_label",
+        "true_label_raw",
+        "predicted_label",
+        "predicted_label_raw",
+        "confidence",
+        "correct",
+        "input_tokens",
+        "output_tokens",
+        "elapsed_seconds",
+        "reasoning",
+        "error",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_summary(path: Path, rows: list[dict[str, Any]]) -> None:
+    completed = [row for row in rows if not row.get("error")]
+    accuracy = (
+        sum(1 for row in completed if row.get("correct")) / len(completed)
+        if completed
+        else None
+    )
+    confusion = Counter(
+        (row.get("true_label"), row.get("predicted_label")) for row in completed
+    )
+    payload = {
+        "total_rows": len(rows),
+        "completed_rows": len(completed),
+        "failed_rows": len(rows) - len(completed),
+        "accuracy": accuracy,
+        "label_distribution_true": Counter(row.get("true_label") for row in completed),
+        "label_distribution_predicted": Counter(row.get("predicted_label") for row in completed),
+        "confusion": {f"{k[0]}->{k[1]}": v for k, v in confusion.items()},
+        "total_input_tokens": sum(row.get("input_tokens") or 0 for row in completed),
+        "total_output_tokens": sum(row.get("output_tokens") or 0 for row in completed),
+        "total_elapsed_seconds": round(sum(row.get("elapsed_seconds") or 0 for row in completed), 3),
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jsonl", action="append", required=True, help="Historical training/testing JSONL path.")
+    parser.add_argument("--model", required=True, help="Model ID to use for reconstructed baseline.")
+    parser.add_argument("--output-csv", required=True, help="Destination CSV.")
+    parser.add_argument("--summary-json", required=True, help="Destination JSON summary.")
+    parser.add_argument("--limit", type=int, default=None, help="Optional max examples.")
+    parser.add_argument("--base-url", default=os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1")
+    args = parser.parse_args()
+
+    examples: list[dict[str, Any]] = []
+    for item in args.jsonl:
+        examples.extend(_load_examples(Path(item)))
+    if args.limit is not None:
+        examples = examples[: args.limit]
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+
+    rows: list[dict[str, Any]] = []
+    for index, example in enumerate(examples, start=1):
+        try:
+            row = classify_example(api_key, args.base_url, args.model, example)
+        except Exception as exc:  # Keep baseline runs resumable/auditable.
+            row = {
+                **{k: example[k] for k in ("source_file", "line_number", "image_url", "image_filename", "true_label", "true_label_raw")},
+                "model": args.model,
+                "predicted_label": "",
+                "predicted_label_raw": "",
+                "confidence": "",
+                "reasoning": "",
+                "raw_response": "",
+                "input_tokens": "",
+                "output_tokens": "",
+                "elapsed_seconds": "",
+                "correct": False,
+                "error": sanitize_error(f"{type(exc).__name__}: {exc}"),
+            }
+        rows.append(row)
+        print(
+            f"{index}/{len(examples)} {row['image_filename']} true={row['true_label']} "
+            f"pred={row.get('predicted_label') or 'ERROR'} correct={row.get('correct')} "
+            f"err={row.get('error') or '-'}",
+            flush=True,
+        )
+        write_csv(Path(args.output_csv), rows)
+        write_summary(Path(args.summary_json), rows)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_prompted_vision_baseline.py
+++ b/tools/run_prompted_vision_baseline.py
@@ -1,0 +1,367 @@
+"""Run a prompted vision-model ICA classification baseline.
+
+This is a read-only evaluation helper for the historical IC_Visual_AI image
+classification dataset. It loads the historical JSONL records only to recover
+image URLs and Grace/reference labels, replaces the old prompt with a supplied
+runtime prompt, calls a Responses-compatible endpoint, and writes row-level CSV
+plus an aggregate JSON summary.
+
+The script does not read or modify EEG/ICA data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import tempfile
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+
+LABEL_MAP = {
+    "brain": "brain",
+    "brain activity": "brain",
+    "eye": "eye",
+    "eye blink": "eye",
+    "eog": "eye",
+    "muscle": "muscle",
+    "muscle artifact": "muscle",
+    "heart": "heart",
+    "heart beat": "heart",
+    "cardiac": "heart",
+    "cardiac artifact": "heart",
+    "ecg": "heart",
+    "line noise": "line_noise",
+    "line_noise": "line_noise",
+    "channel": "channel_noise",
+    "channel noise": "channel_noise",
+    "channel_noise": "channel_noise",
+    "ch_noise": "channel_noise",
+    "other": "other_artifact",
+    "other artifact": "other_artifact",
+    "other_artifact": "other_artifact",
+}
+
+
+def sanitize_error(text: str) -> str:
+    text = re.sub(r"\b(?:sk|clp)(?:[-_][A-Za-z0-9*]+)+", "CREDENTIAL-REDACTED", text)
+    return re.sub(r"Bearer\s+[^\"\s,}]+", "Bearer CREDENTIAL-REDACTED", text)
+
+
+def normalize_label(value: object) -> str:
+    text = str(value or "").strip().lower().replace("-", " ").replace("_", " ")
+    text = re.sub(r"\s+", " ", text)
+    return LABEL_MAP.get(text, text.replace(" ", "_") or "unknown")
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", stripped, re.DOTALL)
+        if not match:
+            raise
+        payload = json.loads(match.group(0))
+    if not isinstance(payload, dict):
+        raise ValueError("model response JSON is not an object")
+    return payload
+
+
+def message_text(response: dict[str, Any]) -> str:
+    output = response.get("output") or []
+    for item in output:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content") or []:
+            text = content.get("text")
+            if text:
+                return str(text)
+    return str(response.get("output_text") or "")
+
+
+def load_examples(paths: list[Path]) -> list[dict[str, Any]]:
+    examples: list[dict[str, Any]] = []
+    for path in paths:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                if not line.strip():
+                    continue
+                payload = json.loads(line)
+                messages = payload["messages"]
+                user_content = messages[1]["content"]
+                image_url = user_content[0]["image_url"]["url"]
+                answer = json.loads(messages[2]["content"])
+                image_name = image_url.rsplit("/", 1)[-1]
+                examples.append(
+                    {
+                        "source_file": str(path),
+                        "line_number": line_number,
+                        "image_filename": image_name,
+                        "image_url": image_url,
+                        "true_label_raw": answer.get("classification"),
+                        "true_label": normalize_label(answer.get("classification")),
+                    }
+                )
+    return examples
+
+
+def call_responses_with_curl(api_key: str, base_url: str, model: str, prompt: str, image_url: str, timeout: int) -> dict[str, Any]:
+    body = {
+        "model": model,
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {"type": "input_image", "image_url": image_url, "detail": "low"},
+                ],
+            }
+        ],
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "ica_component_classification",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string", "enum": ["brain", "channel_noise", "eye", "heart", "line_noise", "muscle", "other_artifact"]},
+                        "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                        "reason": {"type": "string", "minLength": 1, "maxLength": 1000},
+                    },
+                    "required": ["label", "confidence", "reason"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "max_output_tokens": 1024,
+        "store": False,
+    }
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as handle:
+        json.dump(body, handle)
+        body_path = handle.name
+    try:
+        completed = subprocess.run(
+            [
+                "curl",
+                "--silent",
+                "--show-error",
+                "--fail-with-body",
+                "--max-time",
+                str(timeout),
+                base_url.rstrip("/") + "/responses",
+                "-H",
+                f"Authorization: Bearer {api_key}",
+                "-H",
+                "Content-Type: application/json",
+                "--data-binary",
+                "@" + body_path,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    finally:
+        Path(body_path).unlink(missing_ok=True)
+    if completed.returncode != 0:
+        raise RuntimeError(sanitize_error((completed.stderr + "\n" + completed.stdout)[:1000]))
+    return json.loads(completed.stdout)
+
+
+def classify_one(example: dict[str, Any], *, api_key: str, base_url: str, model: str, prompt: str, timeout: int, keep_raw: bool) -> dict[str, Any]:
+    started = time.perf_counter()
+    response = call_responses_with_curl(api_key, base_url, model, prompt, example["image_url"], timeout)
+    elapsed = time.perf_counter() - started
+    text = message_text(response)
+    parsed = extract_json(text)
+    usage = response.get("usage") or {}
+    predicted_raw = parsed.get("label", parsed.get("classification"))
+    predicted = normalize_label(predicted_raw)
+    try:
+        confidence: Any = float(parsed.get("confidence"))
+    except (TypeError, ValueError):
+        confidence = ""
+    row = {
+        **example,
+        "model": model,
+        "predicted_label_raw": predicted_raw or "",
+        "predicted_label": predicted,
+        "confidence": confidence,
+        "reason": parsed.get("reason", parsed.get("reasoning", "")),
+        "agreement": predicted == example["true_label"],
+        "status": "ok",
+        "error": "",
+        "input_tokens": usage.get("input_tokens", ""),
+        "output_tokens": usage.get("output_tokens", ""),
+        "total_tokens": usage.get("total_tokens", ""),
+        "elapsed_seconds": round(elapsed, 3),
+        "response_id": response.get("id", ""),
+    }
+    if keep_raw:
+        row["raw_response"] = text
+    return row
+
+
+def error_row(example: dict[str, Any], model: str, exc: Exception) -> dict[str, Any]:
+    return {
+        **example,
+        "model": model,
+        "predicted_label_raw": "",
+        "predicted_label": "",
+        "confidence": "",
+        "reason": "",
+        "agreement": False,
+        "status": "error",
+        "error": sanitize_error(f"{type(exc).__name__}: {exc}"),
+        "input_tokens": "",
+        "output_tokens": "",
+        "total_tokens": "",
+        "elapsed_seconds": "",
+        "response_id": "",
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]], keep_raw: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "source_file",
+        "line_number",
+        "image_filename",
+        "image_url",
+        "model",
+        "true_label_raw",
+        "true_label",
+        "predicted_label_raw",
+        "predicted_label",
+        "confidence",
+        "reason",
+        "agreement",
+        "status",
+        "error",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "elapsed_seconds",
+        "response_id",
+    ]
+    if keep_raw:
+        fieldnames.append("raw_response")
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_summary(path: Path, rows: list[dict[str, Any]]) -> None:
+    ok = [row for row in rows if row.get("status") == "ok"]
+    correct = sum(1 for row in ok if row.get("agreement") is True)
+    def num(row: dict[str, Any], key: str) -> float:
+        try:
+            return float(row.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0.0
+    elapsed = [num(row, "elapsed_seconds") for row in ok if row.get("elapsed_seconds") not in ("", None)]
+    payload = {
+        "total_rows": len(rows),
+        "completed_rows": len(ok),
+        "failed_rows": len(rows) - len(ok),
+        "accuracy_completed_rows": correct / len(ok) if ok else None,
+        "correct_completed_rows": correct,
+        "accuracy_all_rows": correct / len(rows) if rows else None,
+        "label_distribution_true": dict(Counter(row.get("true_label") for row in ok)),
+        "label_distribution_predicted": dict(Counter(row.get("predicted_label") for row in ok)),
+        "confusion": dict(Counter(f"{row.get('true_label')}->{row.get('predicted_label')}" for row in ok)),
+        "failure_types": dict(Counter(str(row.get("error", "")).split(":", 1)[0] for row in rows if row.get("status") != "ok")),
+        "tokens_completed_rows": {
+            "input_tokens": int(sum(num(row, "input_tokens") for row in ok)),
+            "output_tokens": int(sum(num(row, "output_tokens") for row in ok)),
+            "total_tokens": int(sum(num(row, "total_tokens") for row in ok)),
+            "mean_total_tokens": round(sum(num(row, "total_tokens") for row in ok) / len(ok), 3) if ok else None,
+        },
+        "latency_seconds_completed_rows": {
+            "sum": round(sum(elapsed), 3),
+            "mean": round(sum(elapsed) / len(elapsed), 3) if elapsed else None,
+            "min": round(min(elapsed), 3) if elapsed else None,
+            "max": round(max(elapsed), 3) if elapsed else None,
+        },
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jsonl", action="append", required=True)
+    parser.add_argument("--prompt-file", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output-csv", type=Path, required=True)
+    parser.add_argument("--summary-json", type=Path, required=True)
+    parser.add_argument("--base-url", default=os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--keep-raw-response", action="store_true")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("CLINCOG_API_KEY") or os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_KEY")
+    if not api_key:
+        raise RuntimeError("CLINCOG_API_KEY, OPENAI_API_KEY, or OPENAI_KEY is not set")
+    prompt = args.prompt_file.read_text(encoding="utf-8")
+    examples = load_examples([Path(item) for item in args.jsonl])
+    if args.limit is not None:
+        examples = examples[: args.limit]
+
+    rows: list[dict[str, Any]] = []
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=max(1, args.workers)) as executor:
+        futures = {
+            executor.submit(
+                classify_one,
+                example,
+                api_key=api_key,
+                base_url=args.base_url,
+                model=args.model,
+                prompt=prompt,
+                timeout=args.timeout,
+                keep_raw=args.keep_raw_response,
+            ): index
+            for index, example in enumerate(examples)
+        }
+        by_index: dict[int, dict[str, Any]] = {}
+        for done_count, future in enumerate(as_completed(futures), start=1):
+            index = futures[future]
+            example = examples[index]
+            try:
+                row = future.result()
+            except Exception as exc:
+                row = error_row(example, args.model, exc)
+            by_index[index] = row
+            rows = [by_index[i] for i in sorted(by_index)]
+            write_csv(args.output_csv, rows, args.keep_raw_response)
+            write_summary(args.summary_json, rows)
+            print(
+                f"{done_count}/{len(examples)} {row['image_filename']} true={row['true_label']} "
+                f"pred={row.get('predicted_label') or 'ERROR'} ok={row.get('agreement')} "
+                f"status={row.get('status')} elapsed_total={time.perf_counter() - started:.1f}s",
+                flush=True,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_prompted_vision_baseline.py
+++ b/tools/run_prompted_vision_baseline.py
@@ -12,7 +12,9 @@ The script does not read or modify EEG/ICA data.
 from __future__ import annotations
 
 import argparse
+import base64
 import csv
+import hashlib
 import json
 import os
 import re
@@ -120,16 +122,247 @@ def load_examples(paths: list[Path]) -> list[dict[str, Any]]:
     return examples
 
 
-def call_responses_with_curl(api_key: str, base_url: str, model: str, prompt: str, image_url: str, timeout: int) -> dict[str, Any]:
+
+
+ALLOWED_EVIDENCE_FIELDS_BY_MODE = {
+    "none": set(),
+    "channel_loading_v1": {
+        "evidence_schema_version",
+        "top_channel_label",
+        "top_channel_index_one_based",
+        "largest_abs_loading",
+        "second_largest_abs_loading",
+        "largest_to_second_largest_ratio",
+        "channels_above_50pct_of_max",
+        "channels_above_25pct_of_max",
+        "nearest_neighbor_support_ratio_k4",
+    },
+}
+
+DISALLOWED_EVIDENCE_KEYS = {
+    "true_label",
+    "true_label_raw",
+    "reference_label",
+    "compType",
+    "classification",
+    "label",
+    "predicted_label",
+    "prediction",
+    "agreement",
+    "correct",
+    "grace",
+}
+
+
+def evidence_payload_hash(payload: dict[str, Any] | None) -> str:
+    if payload is None:
+        return ""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_evidence_payload(payload: dict[str, Any], *, row_id: str, evidence_mode: str = "none") -> None:
+    allowed = ALLOWED_EVIDENCE_FIELDS_BY_MODE.get(evidence_mode)
+    if allowed is None:
+        raise ValueError(f"Unknown evidence mode: {evidence_mode}")
+    if evidence_mode == "none":
+        raise ValueError(f"Evidence payload supplied while evidence_mode is none for {row_id}")
+    for key, value in payload.items():
+        key_text = str(key)
+        key_lower = key_text.lower()
+        if key_text not in allowed:
+            raise ValueError(f"Evidence payload for {row_id} contains non-allowlisted key for {evidence_mode}: {key}")
+        if isinstance(value, (dict, list)):
+            raise ValueError(f"Evidence payload for {row_id} contains nested value for {key}")
+        if key_lower == "top_channel_label":
+            continue
+        if key_text in DISALLOWED_EVIDENCE_KEYS or key_lower in {item.lower() for item in DISALLOWED_EVIDENCE_KEYS}:
+            raise ValueError(f"Evidence payload for {row_id} contains disallowed key: {key}")
+        if any(fragment in key_lower for fragment in ("grace", "reference", "predicted", "prediction", "agreement", "correct")):
+            raise ValueError(f"Evidence payload for {row_id} contains disallowed key: {key}")
+    missing = allowed - set(payload)
+    if missing:
+        raise ValueError(f"Evidence payload for {row_id} is missing required keys for {evidence_mode}: {sorted(missing)}")
+
+
+def load_evidence_jsonl(path: Path, evidence_mode: str) -> dict[str, dict[str, Any]]:
+    evidence: dict[str, dict[str, Any]] = {}
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"Evidence line {line_number} is not an object")
+            image_filename = str(payload.get("image_filename") or "").strip()
+            row_key = str(payload.get("row_key") or image_filename).strip()
+            if not image_filename and not row_key:
+                raise ValueError(f"Evidence line {line_number} is missing image_filename/row_key")
+            evidence_payload = payload.get("evidence", payload)
+            if not isinstance(evidence_payload, dict):
+                raise ValueError(f"Evidence line {line_number} evidence is not an object")
+            validate_evidence_payload(evidence_payload, row_id=row_key or image_filename, evidence_mode=evidence_mode)
+            for key in {row_key, image_filename} - {""}:
+                if key in evidence:
+                    raise ValueError(f"Duplicate evidence key: {key}")
+                evidence[key] = evidence_payload
+    if not evidence:
+        raise ValueError("Evidence JSONL has no rows")
+    return evidence
+
+
+def apply_evidence(examples: list[dict[str, Any]], evidence: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    enriched: list[dict[str, Any]] = []
+    for example in examples:
+        row_key = example.get("row_key") or example["image_filename"]
+        payload = evidence.get(str(row_key)) or evidence.get(example["image_filename"])
+        if payload is None:
+            raise ValueError(f"Missing evidence for {example['image_filename']}")
+        enriched.append(
+            {
+                **example,
+                "evidence_payload": payload,
+                "evidence_payload_sha256": evidence_payload_hash(payload),
+            }
+        )
+    return enriched
+
+
+def webp_data_url(path: Path) -> str:
+    data = path.read_bytes()
+    return "data:image/webp;base64," + base64.b64encode(data).decode("ascii")
+
+
+def apply_image_root(examples: list[dict[str, Any]], image_root: Path) -> list[dict[str, Any]]:
+    rewritten: list[dict[str, Any]] = []
+    for example in examples:
+        image_path = image_root / example["image_filename"]
+        if not image_path.is_file():
+            raise ValueError(f"Image root is missing {example['image_filename']}")
+        rewritten.append(
+            {
+                **example,
+                "image_url": webp_data_url(image_path),
+                "image_sha256": sha256_file(image_path),
+                "image_transport": "data_url",
+            }
+        )
+    return rewritten
+
+
+def build_input_content(prompt: str, image_url: str, evidence: dict[str, Any] | None) -> list[dict[str, Any]]:
+    content = [
+        {"type": "input_text", "text": prompt},
+        {"type": "input_image", "image_url": image_url, "detail": "low"},
+    ]
+    if evidence is not None:
+        content.append(
+            {
+                "type": "input_text",
+                "text": (
+                    "AUXILIARY_EVIDENCE_JSON\n"
+                    "The following values are auxiliary observations from the same ICA component, "
+                    "not reference labels or prior model answers.\n"
+                    + json.dumps(evidence, sort_keys=True, separators=(",", ":"))
+                ),
+            }
+        )
+    return content
+
+
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_locked_manifest(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = set(reader.fieldnames or [])
+        if "image_filename" not in fieldnames:
+            raise ValueError("Manifest is missing required column: image_filename")
+        label_column = "true_label" if "true_label" in fieldnames else "compType" if "compType" in fieldnames else None
+        component_column = (
+            "component_number" if "component_number" in fieldnames else "compNum" if "compNum" in fieldnames else None
+        )
+        if label_column is None:
+            raise ValueError("Manifest is missing true_label/compType column")
+        if component_column is None:
+            raise ValueError("Manifest is missing component_number/compNum column")
+        rows = []
+        seen: set[str] = set()
+        for line_number, row in enumerate(reader, start=2):
+            filename = (row.get("image_filename") or "").strip()
+            true_label = normalize_label(row.get(label_column))
+            if not filename:
+                raise ValueError(f"Manifest line {line_number} has empty image_filename")
+            if filename in seen:
+                raise ValueError(f"Manifest contains duplicate image_filename: {filename}")
+            if true_label not in set(LABEL_MAP.values()):
+                raise ValueError(f"Manifest line {line_number} has invalid true_label: {row.get(label_column)!r}")
+            seen.add(filename)
+            rows.append(
+                {
+                    "image_filename": filename,
+                    "component_number": (row.get(component_column) or "").strip(),
+                    "true_label": true_label,
+                    "subset_memberships": (row.get("subset_memberships") or "").strip(),
+                }
+            )
+    if not rows:
+        raise ValueError("Manifest has no rows")
+    return rows
+
+
+def apply_locked_manifest(examples: list[dict[str, Any]], manifest_rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+    by_filename: dict[str, dict[str, Any]] = {}
+    for example in examples:
+        filename = example["image_filename"]
+        if filename in by_filename:
+            raise ValueError(f"Historical JSONL contains duplicate image_filename: {filename}")
+        by_filename[filename] = example
+
+    filtered: list[dict[str, Any]] = []
+    for row in manifest_rows:
+        filename = row["image_filename"]
+        example = by_filename.get(filename)
+        if example is None:
+            raise ValueError(f"Manifest image not found in JSONL examples: {filename}")
+        if normalize_label(example.get("true_label")) != row["true_label"]:
+            raise ValueError(
+                f"Reference label mismatch for {filename}: manifest={row['true_label']} jsonl={example.get('true_label')}"
+            )
+        filtered.append(
+            {
+                **example,
+                "true_label": row["true_label"],
+                "component_number": row["component_number"],
+                "subset_memberships": row["subset_memberships"],
+            }
+        )
+    return filtered
+
+
+def call_responses_with_curl(
+    api_key: str,
+    base_url: str,
+    model: str,
+    prompt: str,
+    image_url: str,
+    timeout: int,
+    evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     body = {
         "model": model,
         "input": [
             {
                 "role": "user",
-                "content": [
-                    {"type": "input_text", "text": prompt},
-                    {"type": "input_image", "image_url": image_url, "detail": "low"},
-                ],
+                "content": build_input_content(prompt, image_url, evidence),
             }
         ],
         "text": {
@@ -186,7 +419,15 @@ def call_responses_with_curl(api_key: str, base_url: str, model: str, prompt: st
 
 def classify_one(example: dict[str, Any], *, api_key: str, base_url: str, model: str, prompt: str, timeout: int, keep_raw: bool) -> dict[str, Any]:
     started = time.perf_counter()
-    response = call_responses_with_curl(api_key, base_url, model, prompt, example["image_url"], timeout)
+    response = call_responses_with_curl(
+        api_key,
+        base_url,
+        model,
+        prompt,
+        example["image_url"],
+        timeout,
+        example.get("evidence_payload"),
+    )
     elapsed = time.perf_counter() - started
     text = message_text(response)
     parsed = extract_json(text)
@@ -212,6 +453,9 @@ def classify_one(example: dict[str, Any], *, api_key: str, base_url: str, model:
         "total_tokens": usage.get("total_tokens", ""),
         "elapsed_seconds": round(elapsed, 3),
         "response_id": response.get("id", ""),
+        "evidence_payload_sha256": example.get("evidence_payload_sha256", ""),
+        "image_sha256": example.get("image_sha256", ""),
+        "image_transport": example.get("image_transport", "url"),
     }
     if keep_raw:
         row["raw_response"] = text
@@ -234,6 +478,9 @@ def error_row(example: dict[str, Any], model: str, exc: Exception) -> dict[str, 
         "total_tokens": "",
         "elapsed_seconds": "",
         "response_id": "",
+        "evidence_payload_sha256": example.get("evidence_payload_sha256", ""),
+        "image_sha256": example.get("image_sha256", ""),
+        "image_transport": example.get("image_transport", "url"),
     }
 
 
@@ -244,6 +491,10 @@ def write_csv(path: Path, rows: list[dict[str, Any]], keep_raw: bool) -> None:
         "line_number",
         "image_filename",
         "image_url",
+        "image_sha256",
+        "image_transport",
+        "component_number",
+        "subset_memberships",
         "model",
         "true_label_raw",
         "true_label",
@@ -259,6 +510,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]], keep_raw: bool) -> None:
         "total_tokens",
         "elapsed_seconds",
         "response_id",
+        "evidence_payload_sha256",
     ]
     if keep_raw:
         fieldnames.append("raw_response")
@@ -268,7 +520,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]], keep_raw: bool) -> None:
         writer.writerows(rows)
 
 
-def write_summary(path: Path, rows: list[dict[str, Any]]) -> None:
+def write_summary(path: Path, rows: list[dict[str, Any]], metadata: dict[str, Any] | None = None) -> None:
     ok = [row for row in rows if row.get("status") == "ok"]
     correct = sum(1 for row in ok if row.get("agreement") is True)
     def num(row: dict[str, Any], key: str) -> float:
@@ -301,6 +553,8 @@ def write_summary(path: Path, rows: list[dict[str, Any]]) -> None:
             "max": round(max(elapsed), 3) if elapsed else None,
         },
     }
+    if metadata:
+        payload["metadata"] = metadata
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
@@ -311,6 +565,14 @@ def main() -> int:
     parser.add_argument("--model", required=True)
     parser.add_argument("--output-csv", type=Path, required=True)
     parser.add_argument("--summary-json", type=Path, required=True)
+    parser.add_argument("--manifest-csv", type=Path, help="Optional locked private manifest selecting image_filename rows to run.")
+    parser.add_argument("--prompt-variant", default="unspecified", help="Run metadata label for the prompt variant.")
+    parser.add_argument("--evidence-jsonl", type=Path, help="Optional label-free JSONL evidence payloads keyed by image_filename.")
+    parser.add_argument("--evidence-mode", default="none", help="Run metadata label for the evidence mode.")
+    parser.add_argument("--image-root", type=Path, help="Optional directory of local WebP images to send as data URLs instead of historical URLs.")
+    parser.add_argument("--image-variant-name", default="historical_url", help="Run metadata label for image transport/variant.")
+    parser.add_argument("--validate-only", action="store_true", help="Validate inputs and metadata without calling the model.")
+    parser.add_argument("--skip-preflight-first", action="store_true", help="Disable the single-row preflight before concurrent requests.")
     parser.add_argument("--base-url", default=os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1")
     parser.add_argument("--limit", type=int)
     parser.add_argument("--workers", type=int, default=1)
@@ -318,16 +580,90 @@ def main() -> int:
     parser.add_argument("--keep-raw-response", action="store_true")
     args = parser.parse_args()
 
-    api_key = os.environ.get("CLINCOG_API_KEY") or os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_KEY")
-    if not api_key:
-        raise RuntimeError("CLINCOG_API_KEY, OPENAI_API_KEY, or OPENAI_KEY is not set")
     prompt = args.prompt_file.read_text(encoding="utf-8")
     examples = load_examples([Path(item) for item in args.jsonl])
+    manifest_hash = None
+    if args.manifest_csv is not None:
+        manifest_hash = sha256_file(args.manifest_csv)
+        examples = apply_locked_manifest(examples, load_locked_manifest(args.manifest_csv))
+    if args.manifest_csv is not None and args.limit is not None:
+        parser.error("--limit cannot be combined with --manifest-csv")
     if args.limit is not None:
         examples = examples[: args.limit]
+    if args.evidence_jsonl is not None:
+        examples = apply_evidence(examples, load_evidence_jsonl(args.evidence_jsonl, args.evidence_mode))
+    if args.image_root is not None:
+        examples = apply_image_root(examples, args.image_root)
+
+    metadata = {
+        "model": args.model,
+        "prompt_variant": args.prompt_variant,
+        "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        "manifest_sha256": manifest_hash,
+        "rows_selected": len(examples),
+        "evidence_mode": args.evidence_mode,
+        "evidence_jsonl_sha256": sha256_file(args.evidence_jsonl) if args.evidence_jsonl else None,
+        "image_variant_name": args.image_variant_name,
+        "image_root": str(args.image_root) if args.image_root else None,
+    }
+
+    if args.validate_only:
+        write_summary(args.summary_json, [], metadata)
+        args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+        args.output_csv.write_text("", encoding="utf-8")
+        print(json.dumps({"validated_rows": len(examples), "metadata": metadata}, indent=2), flush=True)
+        return 0
+
+    if "ai.clincognition.com" in args.base_url:
+        api_key = os.environ.get("CLINCOG_API_KEY")
+        if not api_key:
+            raise RuntimeError("CLINCOG_API_KEY is required for the ClinCog endpoint")
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY or OPENAI_KEY is not set")
 
     rows: list[dict[str, Any]] = []
     started = time.perf_counter()
+    by_index: dict[int, dict[str, Any]] = {}
+
+    def record_progress(done_count: int, index: int, row: dict[str, Any]) -> None:
+        by_index[index] = row
+        current_rows = [by_index[i] for i in sorted(by_index)]
+        write_csv(args.output_csv, current_rows, args.keep_raw_response)
+        write_summary(args.summary_json, current_rows, metadata)
+        if args.manifest_csv is not None:
+            progress = (
+                f"{done_count}/{len(examples)} status={row.get('status')} "
+                f"agreement={row.get('agreement')} elapsed_total={time.perf_counter() - started:.1f}s"
+            )
+        else:
+            progress = (
+                f"{done_count}/{len(examples)} {row['image_filename']} true={row['true_label']} "
+                f"pred={row.get('predicted_label') or 'ERROR'} ok={row.get('agreement')} "
+                f"status={row.get('status')} elapsed_total={time.perf_counter() - started:.1f}s"
+            )
+        print(progress, flush=True)
+
+    start_index = 0
+    if examples and not args.skip_preflight_first:
+        try:
+            first_row = classify_one(
+                examples[0],
+                api_key=api_key,
+                base_url=args.base_url,
+                model=args.model,
+                prompt=prompt,
+                timeout=args.timeout,
+                keep_raw=args.keep_raw_response,
+            )
+        except Exception as exc:
+            first_row = error_row(examples[0], args.model, exc)
+            record_progress(1, 0, first_row)
+            raise RuntimeError(f"Preflight request failed; not launching remaining {len(examples) - 1} requests: {first_row['error']}") from exc
+        record_progress(1, 0, first_row)
+        start_index = 1
+
     with ThreadPoolExecutor(max_workers=max(1, args.workers)) as executor:
         futures = {
             executor.submit(
@@ -340,26 +676,16 @@ def main() -> int:
                 timeout=args.timeout,
                 keep_raw=args.keep_raw_response,
             ): index
-            for index, example in enumerate(examples)
+            for index, example in enumerate(examples[start_index:], start=start_index)
         }
-        by_index: dict[int, dict[str, Any]] = {}
-        for done_count, future in enumerate(as_completed(futures), start=1):
+        for done_offset, future in enumerate(as_completed(futures), start=1):
             index = futures[future]
             example = examples[index]
             try:
                 row = future.result()
             except Exception as exc:
                 row = error_row(example, args.model, exc)
-            by_index[index] = row
-            rows = [by_index[i] for i in sorted(by_index)]
-            write_csv(args.output_csv, rows, args.keep_raw_response)
-            write_summary(args.summary_json, rows)
-            print(
-                f"{done_count}/{len(examples)} {row['image_filename']} true={row['true_label']} "
-                f"pred={row.get('predicted_label') or 'ERROR'} ok={row.get('agreement')} "
-                f"status={row.get('status')} elapsed_total={time.perf_counter() - started:.1f}s",
-                flush=True,
-            )
+            record_progress(start_index + done_offset, index, row)
     return 0
 
 


### PR DESCRIPTION
## What changed

This PR saves the public-safe baseline/comparison slice from the 2026-07-24 ICA classification work:

- Adds aggregate baseline findings for:
  - ICLabel from saved historical EEGLAB ICA vs Grace-reviewed labels.
  - Reconstructed old-prompt GPT-4 Turbo vision baseline vs Grace-reviewed labels.
- Adds a full Terra updated-prompt run summary on the same 679 Grace-reviewed component-image dataset.
- Adds an aggregate ICLabel-vs-Terra comparison report covering accuracy, speed, token usage, per-label precision/recall/F1, and failure modes.
- Adds reusable scripts for:
  - extracting an ICLabel baseline from saved EEGLAB `.set/.fdt` files;
  - reconstructing the old prompt/image-url GPT baseline;
  - running a prompted vision baseline through a Responses-compatible endpoint.

## Main findings

Accuracy is the priority metric:

- ICLabel baseline: 448/679 = 65.98% agreement with Grace.
- Terra updated prompt: 335/679 = 49.34% agreement with Grace.
- Difference: Terra trails ICLabel by 113 correct classifications / 16.64 percentage points.
- Reconstructed old-prompt GPT-4 Turbo: 64/307 = 20.85% agreement on successful rows; incomplete due quota/transport failures.

Speed/token usage:

- ICLabel: 134.7 seconds for 679 rows, about 0.198 seconds/component, 0 LLM tokens.
- Terra: 679/679 completed, 0 failures; observed concurrent wall time 502.2 seconds with 8 workers.
- Terra mean call latency: 5.852 seconds/component; p95 8.969 seconds/component.
- Terra token use: 838,565 input + 124,512 output = 963,077 total tokens, about 1,418.4 tokens/component.
- Old GPT-4 Turbo successful rows: mean 8.675 seconds/component, p95 17.452 seconds/component, about 1,304.4 tokens/success.

Where Terra excels:

- Terra is operationally much cleaner than the reconstructed old GPT baseline: 679/679 completed vs 307/679.
- Compared with ICLabel, Terra's only clear per-class metric win is channel-noise recall: 82.76% vs ICLabel's 55.17%.
- That win is not free: Terra over-calls `channel_noise`, with precision only 13.64%.

Interpretation:

- Terra with the updated prompt is not yet an accuracy improvement over the EEG/ICLabel baseline.
- Terra reduced the old GPT baseline's severe `brain` overprediction, but introduced a different bias toward `channel_noise`.
- The next prompt iteration should tighten channel-noise criteria, strengthen eye/heart criteria, and push mixed cases toward `other_artifact` instead of forced channel-noise.

## Custody/safety boundary

The repository is public, so this PR intentionally does not commit row-level Grace labels, row-level predictions, raw model outputs, server inventories, or historical-key helper code. Those remain local/private evidence artifacts. The committed material is aggregate findings and reusable scripts only.

## Validation

- `python -B -m py_compile tools/extract_iclabel_baseline_from_eeglab.py tools/reconstruct_old_pipeline_baseline.py`
- `python -B -m py_compile tools/run_prompted_vision_baseline.py`
- `git diff --cached --check`